### PR TITLE
Remove postgres dependency.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,6 @@ group :development, :test do
   gem 'sqlite3'
 end
 group :production do
-  gem 'pg'
   gem 'rails_12factor'
 end
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,7 +139,6 @@ GEM
     orm_adapter (0.5.0)
     parser (2.2.2.1)
       ast (>= 1.1, < 3.0)
-    pg (0.18.1)
     polyamorous (1.2.0)
       activerecord (>= 3.0)
     powerpack (0.1.0)
@@ -302,7 +301,6 @@ DEPENDENCIES
   jbuilder (~> 2.0)
   jquery-rails
   launchy
-  pg
   pry-rails
   pry-rescue
   puma


### PR DESCRIPTION
This was failing to install on my machine. Since we're not going to use
postgres, let's remove it and worry about production on a later date.